### PR TITLE
Fixed spelling on getting-started page

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -10,7 +10,7 @@ Windstitch is a **1.4kB**, Simple Styling Library that helps you set **when** a 
 
 By providing Powerful Types through forward declarations, Windstitch aims to be simple yet powerful by limiting itself to be a organizer API, letting Tailwind handle the styling part.
 
-> Although **there's no connection between this lib and [TailwindCSS](https://tailwindcss.com/docs/installation)**, I HIGHLY recommend [installing and using it](https://tailwindcss.com/docs/installation) with this windstitch.
+> Although **there's no connection between this lib and [TailwindCSS](https://tailwindcss.com/docs/installation)**, I HIGHLY recommend [installing and using it](https://tailwindcss.com/docs/installation) with Windstitch.
 
 ## Instalation
 


### PR DESCRIPTION
Removed "this" in "I HIGHLY recommend installing and using it with this windstitch.", and made the name "windstitch" start with a capital letter.