### PR TITLE
fix: fixing  with Infer in the docs

### DIFF
--- a/docs/docs/create-a-component.md
+++ b/docs/docs/create-a-component.md
@@ -55,7 +55,7 @@ export const Button = w.button(
     },
   }
 );
-export type ButtonProps = W.infer<typeof Button>;
+export type ButtonProps = W.Infer<typeof Button>;
 ```
 
 ### Render it
@@ -99,7 +99,7 @@ const Button = w.button('default-class', {
 
 Button.displayName = 'Button';
 
-export type ButtonProps = W.infer<typeof Button>;
+export type ButtonProps = W.Infer<typeof Button>;
 ```
 
 ## Using a Custom Component
@@ -123,5 +123,5 @@ const Checkbox = w(CustomComponent, {
 });
 Checkbox.displayName = 'Checkbox';
 
-export type CheckboxProps = W.infer<typeof Checkbox>;
+export type CheckboxProps = W.Infer<typeof Checkbox>;
 ```

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -71,7 +71,7 @@ const Button = w.button('text-sm', {
     size: 'small',
   },
 });
-type ButtonProps = W.infer<typeof Button>;
+type ButtonProps = W.Infer<typeof Button>;
 ```
 
 `ButtonProps` have all native `button` props with `{ color: 'red' | 'blue', size?: 'small' | 'large' }`. You can set the `as` to set which component should be rendered. It also changes the expected prop types

--- a/docs/docs/variants.md
+++ b/docs/docs/variants.md
@@ -23,7 +23,7 @@ const Button = w.button('bg-white', {
     },
   },
 });
-type ButtonProps = W.infer<typeof Button>;
+type ButtonProps = W.Infer<typeof Button>;
 // ButtonProps['color'] is 'gray' | 'red'
 ```
 
@@ -39,7 +39,7 @@ const Checkbox = w.input('bg-white', {
     checked: (yes: boolean) => (yes ? 'bg-indigo-500' : 'bg-white'),
   },
 });
-type CheckboxProps = W.infer<typeof Checkbox>;
+type CheckboxProps = W.Infer<typeof Checkbox>;
 // CheckboxProps['checked'] is boolean
 ```
 
@@ -63,7 +63,7 @@ const Checkbox = w.input('bg-white', {
     checked: false,
   },
 });
-type CheckboxProps = W.infer<typeof Checkbox>;
+type CheckboxProps = W.Infer<typeof Checkbox>;
 // CheckboxProps['checked'] is boolean | undefined
 // CheckboxProps['color'] is 'gray' | 'red' | undefined
 ```


### PR DESCRIPTION
# Changelog

I think the docs have a typo, however if this is a mistake please disregard my pull request

in the docs it show the usage of `infer` like this 
```js
const ButtonSSS = w.button('text-sm', {
  variants: {
    color: {
      red: 'bg-red-500',
      blue: 'bg-blue-200',
    },
    size: {
      small: 'px-2 py-1',
      large: 'px-4 py-2',
    },
  },
});
type ButtonPropssss = W.infer<typeof ButtonSSS>;
```
however this will result in TS error, saying that `infer` is not found, however when you. change it to this
`type ButtonPropssss = W.Infer<typeof ButtonSSS>;`

works correctly, and not TS error.
Once again if this a mistake from my side, please do ignore my pull request 

Cheers,
Enyel